### PR TITLE
Ability to get price in Satoshis

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const request = require('request')
 const ftploy = require('ftploy')
 const JSFtp = require('jsftp')
 const fs = require('fs')
+const BigNumber = require('bignumber.js')
 const client = new Discord.Client({autoReconnect: true})
 
 const config = require('./config.json')
@@ -163,7 +164,34 @@ client.on('message', message => {
     })
   }
   
-  
+  if (command === 'sats') {
+    message.delete()
+    message.channel.send({
+      embed: {
+        color: 16750848,
+        title: 'Please wait ...'
+      }
+    }).then((message) => {
+        getCoinData(args[0], message, function (message, data) {
+          if (data) {
+            //Some really small coins don't have prices listed, handle case
+            var satPrice = data.price_btc !== null ? BigNumber(data.price_btc).times(100000000).toString() + " sats" : "Unknown price";
+            const embed = new Discord.RichEmbed()
+              .setColor('#ffc107')
+              .setTitle(data.name + ' (' + data.symbol + ') stats')
+              .setDescription('[More info here](' + cmMoreInfoRoot + data.id + '/)')
+              .setThumbnail(cmImageRoot + data.id + '.png')
+              .addField('Price in Satoshis', satPrice);
+            message.edit({embed})
+      } else {
+          const embed = new Discord.RichEmbed()
+            .setColor('#ffc107')
+            .setTitle('Not available')
+          message.edit({embed})
+        }
+      })
+    })
+  }
   
   if (command === 'marketcap') {
     message.delete()
@@ -218,7 +246,7 @@ client.on('message', message => {
     message.author.send(getHelpMessage())
   }
   if (command === 'hhelp') {
-    message.author.send(getHelpMessage())
+    message.channel.send(getHelpMessage())
   }
   if (command === 'eval') {
     if (message.author.id !== config.ownerID) return
@@ -289,6 +317,7 @@ function getHelpMessage() {
     .addField('$help', 'See all commands in DM')
     .addField('$hhelp', 'See all commands in global channel')
     .addField('$money <money>', 'See the value of a currency in USD. \nSupport name and symbol \n__Example :__ `$money bitcoin` or `$money BTC`')
+    .addField('$sats <coin>', 'See the value of a currency in sats. \nSupport name and symbol \n__Example :__ `$sats Ethereum` or `$sats ETH`')
     .addField('$marketcap', 'See all informations about the martket cap')
     .addField('$stats', 'Some stats about the bot')
     .addField(':dollar: SUPPORT ME', 'You can send me some cryptocurrencies to help me in the development of the bot')

--- a/app.js
+++ b/app.js
@@ -9,6 +9,10 @@ const client = new Discord.Client({autoReconnect: true})
 const config = require('./config.json')
 const prefix = config.prefix
 
+const cmImageRoot = "https://files.coinmarketcap.com/static/img/coins/32x32/"
+const cmMoreInfoRoot = "https://coinmarketcap.com/currencies/"
+
+
 const ftpInformation = {
   username: config.FTPLogin.user,
   password: config.FTPLogin.password,
@@ -192,11 +196,11 @@ client.on('message', message => {
   if (command === 'stats') {
     const embed = new Discord.RichEmbed()
       .setColor('#ffc107') // Alternatively, use "#00AE86", [0, 174, 134] or an integer number.
-      // .setAuthor('CryptoBot', 'https://files.coinmarketcap.com/static/img/coins/32x32/bitcoin.png')
+      // .setAuthor('CryptoBot', cmImageRoot + 'bitcoin.png')
       // .setTitle('This is your title, it can hold 256 characters')
       // .setURL('https://discord.js.org/#/docs/main/indev/class/RichEmbed')
       // .setDescription('This is the main body of text, it can hold 2048 characters.')
-      .setThumbnail('https://files.coinmarketcap.com/static/img/coins/32x32/bitcoin.png')
+      .setThumbnail(cmImageRoot + 'bitcoin.png')
       .addField('Total server', client.guilds.size, true)
       .addField('Total users', client.guilds.reduce((mem, g) => mem += g.memberCount, 0), true)
       .addField('Version:', config.botVersion, true)
@@ -210,53 +214,11 @@ client.on('message', message => {
     message.channel.send({embed})
   }
   if (command === 'help') {
-    const embed = new Discord.RichEmbed()
-      .setColor('#ffc107') // Alternatively, use "#00AE86", [0, 174, 134] or an integer number.
-      .setAuthor('CryptoBot', 'https://files.coinmarketcap.com/static/img/coins/32x32/bitcoin.png')
-      .addField(':information_source: INFORMATIONS', 'Some informations about the bot')
-      .addField('Add the bot to your server', 'https://cryptobot.lucasalt.fr/', true)
-      .addField('Version:', config.botVersion, true)
-      .addField('Discord.js version:', '11.2.1', true)
-      .addField('Made by:', '<@176759285366128641>', true)
-      .addField('Join me here:', 'https://discord.gg/4HqYAjy', true)
-      .addField('Now available on GitHub:', 'https://github.com/MrDragonXM15/CryptoBot')
-      .addField(':level_slider: COMMANDS', 'All commands for the bot')
-      .addField('$help', 'See all commands in DM')
-      .addField('$hhelp', 'See all commands in global channel')
-      .addField('$money <money>', 'See the value of a currency. \nSupport name and symbol \n__Example :__ `$money bitcoin` or `$money BTC`')
-      .addField('$marketcap', 'See all informations about the martket cap')
-      .addField('$stats', 'Some stats about the bot')
-      .addField(':dollar: SUPPORT ME', 'You can send me some cryptocurrencies to help me in the development of the bot')
-      .addField('Dogecoin', '`DNbD8 Dnts staV JxeC 54gT wdGL LdLW XuTgX`')
-      .addField('Litecoin', '`LPTu 5JMw BVAw RLni5 Jv6R 9xK9 Y9QX vXo1f`')
-      .addField('Dash', '`XTxxG FTdY f2sv rAi2 Ym3S GUbG XnBL 12gor`')
-      .addField('Ethereum', '`0x58 94e3 2413 34df 48f5b 1992 1444 2bfd b0bf f4b5b`')
     message.reply('A message containing the bot commands has been sent to you!')
-    message.author.send({embed})
+    message.author.send(getHelpMessage())
   }
   if (command === 'hhelp') {
-    const embed = new Discord.RichEmbed()
-      .setColor('#ffc107') // Alternatively, use "#00AE86", [0, 174, 134] or an integer number.
-      .setAuthor('CryptoBot', 'https://files.coinmarketcap.com/static/img/coins/32x32/bitcoin.png')
-      .addField(':information_source: INFORMATIONS', 'Some informations about the bot')
-      .addField('Add the bot to your server', 'https://cryptobot.lucasalt.fr/', true)
-      .addField('Version:', config.botVersion, true)
-      .addField('Discord.js version:', '11.2.1', true)
-      .addField('Made by:', '<@176759285366128641>', true)
-      .addField('Join me here:', 'https://discord.gg/4HqYAjy', true)
-      .addField('Now available on GitHub:', 'https://github.com/MrDragonXM15/CryptoBot')
-      .addField(':level_slider: COMMANDS', 'All commands for the bot')
-      .addField('$help', 'See all commands in DM')
-      .addField('$hhelp', 'See all commands in global channel')
-      .addField('$money <money>', 'See the value of a currency. \nSupport name and symbol \n__Example :__ `$money bitcoin` or `$money BTC`')
-      .addField('$marketcap', 'See all informations about the martket cap')
-      .addField('$stats', 'Some stats about the bot')
-      .addField(':dollar: SUPPORT ME', 'You can send me some cryptocurrencies to help me in the development of the bot')
-      .addField('Dogecoin', '`DNbD8 Dnts staV JxeC 54gT wdGL LdLW XuTgX`')
-      .addField('Litecoin', '`LPTu 5JMw BVAw RLni5 Jv6R 9xK9 Y9QX vXo1f`')
-      .addField('Dash', '`XTxxG FTdY f2sv rAi2 Ym3S GUbG XnBL 12gor`')
-      .addField('Ethereum', '`0x58 94e3 2413 34df 48f5b 1992 1444 2bfd b0bf f4b5b`')
-    message.channel.send({embed})
+    message.author.send(getHelpMessage())
   }
   if (command === 'eval') {
     if (message.author.id !== config.ownerID) return
@@ -310,6 +272,31 @@ function getCoinData(coinKey, discordMsg, callback) {
       discordMsg.channel.sendMessage('```Error when processing coin info! ' + err + '```');
     }
   })
+}
+
+function getHelpMessage() {
+  var embed = new Discord.RichEmbed()
+    .setColor('#ffc107') // Alternatively, use "#00AE86", [0, 174, 134] or an integer number.
+    .setAuthor('CryptoBot', cmImageRoot + 'bitcoin.png')
+    .addField(':information_source: INFORMATIONS', 'Some informations about the bot')
+    .addField('Add the bot to your server', 'https://cryptobot.lucasalt.fr/', true)
+    .addField('Version:', config.botVersion, true)
+    .addField('Discord.js version:', '11.2.1', true)
+    .addField('Made by:', '<@176759285366128641>', true)
+    .addField('Join me here:', 'https://discord.gg/4HqYAjy', true)
+    .addField('Now available on GitHub:', 'https://github.com/MrDragonXM15/CryptoBot')
+    .addField(':level_slider: COMMANDS', 'All commands for the bot')
+    .addField('$help', 'See all commands in DM')
+    .addField('$hhelp', 'See all commands in global channel')
+    .addField('$money <money>', 'See the value of a currency in USD. \nSupport name and symbol \n__Example :__ `$money bitcoin` or `$money BTC`')
+    .addField('$marketcap', 'See all informations about the martket cap')
+    .addField('$stats', 'Some stats about the bot')
+    .addField(':dollar: SUPPORT ME', 'You can send me some cryptocurrencies to help me in the development of the bot')
+    .addField('Dogecoin', '`DNbD8 Dnts staV JxeC 54gT wdGL LdLW XuTgX`')
+    .addField('Litecoin', '`LPTu 5JMw BVAw RLni5 Jv6R 9xK9 Y9QX vXo1f`')
+    .addField('Dash', '`XTxxG FTdY f2sv rAi2 Ym3S GUbG XnBL 12gor`')
+    .addField('Ethereum', '`0x58 94e3 2413 34df 48f5b 1992 1444 2bfd b0bf f4b5b`')
+  return embed;
 }
 
 client.login(config.token.dev)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptobot",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A discord bot who give you the current value of a cryptocurrency",
   "main": "app.js",
   "repository": {
@@ -17,6 +17,7 @@
     "cryptocurrency"
   ],
   "author": "LucasAlt",
+  "contributors": [{"name":"Chet Michals", "email" : "chetmichals@gmail.com"}],
   "license": "MIT",
   "devDependencies": {
     "discord.js": "^11.2.1",
@@ -29,7 +30,8 @@
     "fs": "0.0.1-security",
     "ftploy": "0.0.4",
     "jsftp": "^2.1.2",
-    "request": "^2.83.0"
+    "request": "^2.83.0",
+    "bignumber.js": "^5.0.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Did the following things in these commits:
* Added the ability get to the current price in Satoshis with a new command, $sats <coin>, which works similarly to $money. For a lot of smaller coins, this is often how we discuss the price. 
* Redid how data is pulled from Coin Market Caps for a specific coin. This was done to reduce duplication for the $sats command, since they both use the same methodology to get data. New version makes less API calls, is case insensitive, and corrects a subtle bug when no coin name is entered.
 For the case insensitivity, I took a bit of time to write up a quick script that checked all the coins listed on Coin Market Caps, while there are some coins with overlapping symbols, there is no current coin where the case sensitivity would differentiate the coin. The minor bug that occured was when no name was entered (So if you just did "$money") it would still make a request for all the coin data on Coin Market Caps, when it could never successfully find the coin.
* Consolidated the code to generate the help message into a single function, so a person can't accidentally update just one help command.
* Moved some of repeated URLs into constants. Possible could help if the location of the images or the page the user is linked get a new location.


Let me know if you encounter any issues or have questions with what was done. I tried to break it down into multiple commits that are tighter focused.